### PR TITLE
Add installation via go get

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ It supports only Xresources. However, you can input a ```Tamplate``` for your co
 ## Requirements
 Nope, only Go standard libraries (I wrote the coloring algorithm by myself, compactly). You need ```xrdb``` to set Xresources however.
 
+## Installation
+`go get github.com/SeungheonOh/colterm`  
+Make sure you have your `GOPATH` set, e.g.:  
+```bash
+export GOPATH=/home/$USER/go
+export PATH=$PATH:$GOPATH/bin
+```
+
 ## Usage
 ```
 USAGE:

--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ It supports only Xresources. However, you can input a ```Tamplate``` for your co
 Nope, only Go standard libraries (I wrote the coloring algorithm by myself, compactly). You need ```xrdb``` to set Xresources however.
 
 ## Installation
-`go get github.com/SeungheonOh/colterm`  
-Make sure you have your `GOPATH` set, e.g.:  
+`go get github.com/SeungheonOh/colterm`
+
+Make sure you have your `GOPATH` set, e.g. in your `.bashrc`:  
 ```bash
 export GOPATH=/home/$USER/go
 export PATH=$PATH:$GOPATH/bin


### PR DESCRIPTION
Add installation instructions via `go get` and information about `GOPATH` for first time users of go.